### PR TITLE
packet: add payload getter

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -179,6 +179,24 @@ impl Packet {
     pub fn set_payload(&mut self, payload: &[u8]) -> () {
         self.payload.extend_from_slice(payload);
     }
+    /// Get the payload for the packet
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate packet_rs; use packet_rs::headers::*; use packet_rs::Packet;
+    /// let mut pkt = Packet::new();
+    /// pkt.push(Ether::new());
+    /// pkt.push(Vlan::new());
+    /// pkt.push(IPv4::new());
+    /// // vupdate the payload
+    /// let pld: Vec<u8> = Vec::from([1, 2, 3, 4, 5]);
+    /// pkt.set_payload(pld.as_slice());
+    /// assert_eq!(pkt.payload(), pld.as_slice());
+    /// ```
+    #[inline(always)]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
     /// Get immutable access to a header from the packet
     /// # Example
     ///
@@ -702,6 +720,9 @@ impl<'a> PacketSlice<'a> {
     }
     pub(crate) fn set_payload(&mut self, payload: &'a [u8]) -> () {
         self.payload = payload;
+    }
+    pub fn payload(&self) -> &[u8] {
+        self.payload
     }
     pub fn to_vec(&self) -> Vec<u8> {
         let mut r = Vec::new();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -679,8 +679,7 @@ mod tests {
         }
     }
 
-    fn test_tcp_packet() -> Packet {
-        let payload: Vec<u8> = (0..100).collect::<Vec<u8>>();
+    fn test_tcp_packet_with_payload(payload: &[u8]) -> Packet {
         utils::create_tcp_packet(
             "00:11:11:11:11:11",
             "00:06:07:08:09:0a",
@@ -705,9 +704,15 @@ mod tests {
             0,
             0,
             false,
-            &payload,
+            payload,
         )
     }
+
+    fn test_tcp_packet() -> Packet {
+        let payload: Vec<u8> = (0..100).collect::<Vec<u8>>();
+        test_tcp_packet_with_payload(&payload)
+    }
+
     #[test]
     fn update_packet_test() {
         let mut pkt = test_tcp_packet();
@@ -809,5 +814,25 @@ mod tests {
             p.to_vec();
         }
         println!("{} packets parsed   : {:?}", cnt, start.elapsed());
+    }
+    #[test]
+    fn packet_slice_payload_test() {
+        let payload: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let pkt = test_tcp_packet_with_payload(payload).to_vec();
+
+        let slice = pkt.as_slice();
+
+        let p = parser::fast::parse(&slice);
+        assert_eq!(p.payload(), payload);
+    }
+    #[test]
+    fn packet_payload_test() {
+        let payload: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let pkt = test_tcp_packet_with_payload(payload).to_vec();
+
+        let slice = pkt.as_slice();
+
+        let p = parser::slow::parse(&slice);
+        assert_eq!(p.payload(), payload);
     }
 }


### PR DESCRIPTION
It is not currently possible to access the payload directly from the packet while it is readily available.
Currently, the alternative is to `packet_rs::slow::parse`, then pop all the layers to then be able to access the payload with: `packet.to_vec()`.

This change allow to access the packet payload directly from a `Packet` or `PacketSlice`, making this both work for slow or fast parsing.

Tests are also added to validate the functionality.